### PR TITLE
Add functions to test string and text file matching

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,15 @@ Change history for MP-Test
 Changes since 7.1
 -----------------
 
+#### 11/10/22
+  - Add `t_str_match()` to test that a string/char array matches an
+    expected value. Includes the option to apply a set of regular expression
+    or simple string replacements before comparing.
+  - Add `t_file_match()` to test that the contents of two text files
+    match, with the option to delete one if they do match. Includes
+    the option to apply a set of string or regular expresssion replacements
+    before comparing.
+
 #### 4/10/21
   - Allow `logical` type (i.e. `true` and `false`) as second input to
     `have_feature()`, as well as `numeric` type (1 and 0), to facilitate

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ particular function.
 - __t_is__ — test if two (scalar, vector, matrix) values are identical,
   to some tolerance
   ```
-  t_is(got, expected, prec, msg)
+  ok = t_is(got, expected, prec, msg)
   ```
   Increments the global test count and if the maximum difference between
   corresponding elements of `got` and `expected` is less than
@@ -150,6 +150,45 @@ particular function.
 
   Optionally returns a true or false value indicating whether or not the
   test succeeded. `NaN` values are considered to be equal to each other.
+
+- __t_str_match__ — test if two strings match, with optional replacements
+  ```
+  ok = t_str_match(got, expected, msg)
+  ok = t_str_match(got, expected, msg, reps)
+  ```
+  This is equivalent to `t_ok(strcmp(got, expected), msg)`, with the
+  option to apply replacements to `got`, and optionally to `expected`,
+  as specified by `reps` before comparing.
+
+  The `reps` argument is a cell array of replacement specs, applied
+  sequentially, where each replacement spec is a cell array of the
+  following form:  
+      `{original, replacement}`  
+      `{original, replacement, re}`  
+      `{original, replacement, re, both}`  
+  The `original` and `replacement` arguments are passed directly as the
+  2nd and 3rd arguments to `regexprep` (or to `strrep` if `re` is present
+  and false). The replacement applies to `got` only, unless `both` is
+  present and true, in which case it also applies to `expected`.
+
+- __t_files_match__ — test if the contents of two text files match
+  ```
+  ok = t_file_match(got_fname, exp_fname, msg)
+  ok = t_file_match(got_fname, exp_fname, msg, reps)
+  ok = t_file_match(got_fname, exp_fname, msg, reps, del_got_fname)
+  ```
+  Uses `t_str_match()` on the contents of two text files whose names/paths
+  are given in `got_fname` and `exp_fname`. If both files exist and the
+  contents match, the test passes.
+
+  It ignores any differences in line ending characters and, like
+  `t_str_match()`, can apply replacements to the contents of `got_fname`,
+  and optionally `exp_fname`, as specified by `reps` before comparing.
+
+  See __t_str_match__ above for a description of the `reps` argument.
+
+  If `del_got_fname` is present and true it will delete the file named
+  in `got_fname` if the test passes.
 
 - __t_skip__ — skip a number of tests
   ```

--- a/lib/mptestver.m
+++ b/lib/mptestver.m
@@ -7,7 +7,7 @@ function rv = mptestver(varargin)
 %   installation of MP-Test.
 
 %   MP-Test
-%   Copyright (c) 2010-2020, Power Systems Engineering Research Center (PSERC)
+%   Copyright (c) 2010-2022, Power Systems Engineering Research Center (PSERC)
 %   by Ray Zimmerman, PSERC Cornell
 %
 %   This file is part of MP-Test.
@@ -15,9 +15,9 @@ function rv = mptestver(varargin)
 %   See https://github.com/MATPOWER/mptest for more info.
 
 v = struct( 'Name',     'MP-Test', ... 
-            'Version',  '7.1', ...
+            'Version',  '8.0-dev', ...
             'Release',  '', ...
-            'Date',     '08-Oct-2020' );
+            'Date',     '10-Nov-2022' );
 if nargout > 0
     if nargin > 0
         rv = v;

--- a/lib/t/t_test_fcns.m
+++ b/lib/t/t_test_fcns.m
@@ -2,7 +2,7 @@ function t_test_fcns(quiet)
 %T_TEST_FCNS  Test T_OK and T_IS and manually check output of failed tests.
 
 %   MP-Test
-%   Copyright (c) 2015, Power Systems Engineering Research Center (PSERC)
+%   Copyright (c) 2015, 2022, Power Systems Engineering Research Center (PSERC)
 %   by Ray Zimmerman, PSERC Cornell
 %
 %   This file is part of MP-Test.
@@ -14,8 +14,8 @@ if nargin < 1
 end
 
 ntests = 5;
-npass = 9;
-nfail = 12;
+npass = 29;
+nfail = 18;
 
 g = [];
 e = [];
@@ -27,6 +27,7 @@ f = @(s) str{s+1};
 
 t_begin(npass+nfail, quiet);
 
+%% t_ok
 k = k + 1; e(k) = 1;
 t = sprintf('%s : t_ok(1, ...)', f(e(k)));
 g(k) = t_ok(1, t);
@@ -35,6 +36,7 @@ k = k + 1; e(k) = 0;
 t = sprintf('%s : t_ok(0, ...)', f(e(k)));
 g(k) = t_ok(0, t);
 
+%% t_is
 k = k + 1; e(k) = 1;
 t = sprintf('%s : t_is([], [], ...)', f(e(k)));
 expected = [];
@@ -151,6 +153,147 @@ expected = 0.6;
 got = int32(1.0);
 g(k) = t_is(got, expected, tol, t);
 
+%% t_str_match
+k = k + 1; e(k) = 1;
+t = sprintf('%s : t_str_match(got, expected, ...)', f(e(k)));
+expected = 'hello t_str_match';
+got = 'hello t_str_match';
+g(k) = t_str_match(got, expected, t);
+
+k = k + 1; e(k) = 0;
+t = sprintf('%s : t_str_match(got, expected, ...)', f(e(k)));
+expected = 'hello t_str_match';
+got = 'herro t_str_match';
+g(k) = t_str_match(got, expected, t);
+
+k = k + 1; e(k) = 1;
+t = sprintf('%s : t_str_match(... reps[re])', f(e(k)));
+expected = 'hello t_str_match';
+got = 'herro t_str_match';
+reps = {{'r{2}', 'll'}};
+g(k) = t_str_match(got, expected, t, reps);
+
+k = k + 1; e(k) = 0;
+t = sprintf('%s : t_str_match(... reps[re])', f(e(k)));
+expected = 'hello t_str_match';
+got = 'herro t_str_match';
+reps = {{'r{2}', 'LL'}};
+g(k) = t_str_match(got, expected, t, reps);
+
+k = k + 1; e(k) = 1;
+t = sprintf('%s : t_str_match(... reps[!re])', f(e(k)));
+expected = 'hello t_str_match';
+got = 'herro t_str_match';
+reps = {{'rr', 'll', 0}};
+g(k) = t_str_match(got, expected, t, reps);
+
+k = k + 1; e(k) = 0;
+t = sprintf('%s : t_str_match(... reps[!re])', f(e(k)));
+expected = 'hello t_str_match';
+got = 'herro t_str_match';
+reps = {{'r{2}', 'll', 0}};
+g(k) = t_str_match(got, expected, t, reps);
+
+k = k + 1; e(k) = 1;
+t = sprintf('%s : t_str_match(... reps[both])', f(e(k)));
+expected = 'hel4o t_str_match';
+got = 'he56o t_str_match';
+reps = {{'\d', 'l', 1, 1}};
+g(k) = t_str_match(got, expected, t, reps);
+
+k = k + 1; e(k) = 0;
+t = sprintf('%s : t_str_match(... reps[both])', f(e(k)));
+expected = 'heL4o t_str_match';
+got = 'he56o t_str_match';
+reps = {{'\d', 'l', 1, 1}};
+g(k) = t_str_match(got, expected, t, reps);
+
+%% t_file_match
+[twd, n, ext] = fileparts(which('t_test_fcns'));
+exp_fname = fullfile(twd, 't_have_feature', 'rithmaticker.m');
+num = fix(1e7*rand);
+fname1 = sprintf('test-output-1-%d.txt', num);
+fname2 = sprintf('test-output-2-%d.txt', num);
+fname3 = sprintf('test-output-3-%d.txt', num);
+ex = fileread(exp_fname);
+if isempty(strfind(ex, char([13 10])))
+    ex2 = strrep(ex, char(10), char([13 10]));
+else
+    ex2 = strrep(ex, char([13 10]), char(10));
+end
+ex3 = regexprep(ex2, '\d', 'N');
+
+k = k + 1; e(k) = 1;
+t = sprintf('%s : fileread', f(e(k)));
+g(k) = t_ok(strcmp(ex(1:8), 'function'), t);
+
+%% write files
+filewrite(fname1, ex);
+filewrite(fname2, ex2);
+filewrite(fname3, ex3);
+
+k = k + 1; e(k) = 1;
+t = sprintf('%s : filewrite 1', f(e(k)));
+ok = exist(fname1, 'file') == 2 && strcmp(ex, fileread(fname1));
+g(k) = t_ok(ok, t);
+
+k = k + 1; e(k) = 1;
+t = sprintf('%s : filewrite 2', f(e(k)));
+ok = exist(fname2, 'file') == 2 && ~strcmp(ex, fileread(fname2));
+g(k) = t_ok(ok, t);
+
+k = k + 1; e(k) = 1;
+t = sprintf('%s : filewrite 3', f(e(k)));
+ok = exist(fname3, 'file') == 2 && ~strcmp(ex, fileread(fname3));
+g(k) = t_ok(ok, t);
+
+%% t_file_match
+k = k + 1; e(k) = 1;
+t = sprintf('%s : t_file_match 1', f(e(k)));
+g(k) = t_file_match(fname1, exp_fname, t);
+k = k + 1; e(k) = 1;
+g(k) = t_ok(exist(fname1, 'file') == 2, [t ' : file not deleted']);
+
+k = k + 1; e(k) = 1;
+t = sprintf('%s : t_file_match 1 (del)', f(e(k)));
+g(k) = t_file_match(fname1, exp_fname, t, {}, 1);
+k = k + 1; e(k) = 1;
+g(k) = t_ok(exist(fname1, 'file') == 0, [t ' : file deleted']);
+
+k = k + 1; e(k) = 1;
+t = sprintf('%s : t_file_match 2', f(e(k)));
+g(k) = t_file_match(fname2, exp_fname, t);
+k = k + 1; e(k) = 1;
+g(k) = t_ok(exist(fname2, 'file') == 2, [t ' : file not deleted']);
+
+k = k + 1; e(k) = 1;
+t = sprintf('%s : t_file_match 2 (del)', f(e(k)));
+g(k) = t_file_match(fname2, exp_fname, t, {}, 1);
+k = k + 1; e(k) = 1;
+g(k) = t_ok(exist(fname2, 'file') == 0, [t ' : file deleted']);
+
+k = k + 1; e(k) = 0;
+t = sprintf('%s : t_file_match 3 (del)', f(e(k)));
+g(k) = t_file_match(fname3, exp_fname, t, {}, 1);
+k = k + 1; e(k) = 1;
+g(k) = t_ok(exist(fname3, 'file') == 2, [t ' : file not deleted']);
+
+k = k + 1; e(k) = 0;
+t = sprintf('%s : t_file_match 3 (reps,del)', f(e(k)));
+reps = {{'\d', 'N', 1}};
+g(k) = t_file_match(fname3, exp_fname, t, reps);
+k = k + 1; e(k) = 1;
+g(k) = t_ok(exist(fname3, 'file') == 2, [t ' : file not deleted']);
+
+k = k + 1; e(k) = 1;
+t = sprintf('%s : t_file_match 3 (both,del)', f(e(k)));
+reps = {{'[\dN]', 'M', 1, 1}};
+g(k) = t_file_match(fname3, exp_fname, t, reps, 1);
+k = k + 1; e(k) = 1;
+g(k) = t_ok(exist(fname3, 'file') == 0, [t ' : file deleted']);
+
+
+
 %%-----  reset tests, if this test passes, everything is as expected  -----
 t_begin(ntests, quiet);
 
@@ -166,3 +309,12 @@ t = 'passes and fails all as expected';
 t_is(g, e, tol, t);
 
 t_end;
+
+
+function filewrite(fname, content)
+[fid, msg] = fopen(fname, 'w');
+if fid == -1
+    error('%s\nt_test_fcns/filewrite: could not write file ''%s''', msg, fname);
+end
+fprintf(fid, '%s', content);
+fclose(fid);

--- a/lib/t_file_match.m
+++ b/lib/t_file_match.m
@@ -67,6 +67,9 @@ if got_exists
     got = fileread(got_fname);
     expected = fileread(exp_fname);
 
+    %% ignore line endings by replacing Win EOL with Unix EOL chars
+    reps = {{char([13 10]), char(10), 0, 1}, reps{:}};
+
     %% check if contents match
     TorF = t_str_match(got, expected, msg, reps);
     

--- a/lib/t_file_match.m
+++ b/lib/t_file_match.m
@@ -1,0 +1,83 @@
+function ok = t_file_match(got_fname, exp_fname, msg, reps, del_got_fname)
+%T_FILE_MATCH  Tests whether two text files match.
+%   T_FILE_MATCH(GOT_FNAME, EXP_FNAME, MSG)
+%   T_FILE_MATCH(GOT_FNAME, EXP_FNAME, MSG, REPS)
+%   T_FILE_MATCH(GOT_FNAME, EXP_FNAME, MSG, REPS, DEL_GOT_FNAME)
+%   Uses T_STR_MATCH on the contents of two text files whos names/paths
+%   are given in GOT_FNAME and EXP_FNAME. If both files exist and the
+%   contents match, the test passes.
+%
+%   It ignores any differences in line ending characters and, like
+%   T_STR_MATCH, can apply replacements to the contents of GOT_FNAME,
+%   and optionally EXP_FNAME, as specified by REPS before comparing.
+%
+%   The REPS argument is a cell array of replacement specs, applied
+%   sequentially, where each replacement spec is a cell array of the
+%   following form:
+%       {ORIGINAL, REPLACEMENT}
+%       {ORIGINAL, REPLACEMENT, RE}
+%       {ORIGINAL, REPLACEMENT, RE, BOTH}
+%   The ORIGINAL and REPLACEMENT arguments are passed directly as the
+%   2nd and 3rd arguments to REGEXPREP (or to STRREP if RE is present
+%   and false). The replacement applies to GOT_FNAME only, unless BOTH is
+%   present and true, in which case it also applies to EXP_FNAME.
+%
+%   If DEL_GOT_FNAME is present and true it will delete the file named
+%   in GOT_FNAME if the test passes.
+%
+%   Optionally returns a true or false value indicating whether or
+%   not the test succeeded.
+%
+%   Example:
+%       quiet = 0;
+%       t_begin(5, quiet);
+%
+%       % replace Windows EOL chars with Unix EOL chars
+%       reps = {{char([13 10]), char(10), 0, 1}};
+%       got_fname = 'test_generated_output.txt';
+%       exp_fname = 'expected_output.txt';
+%       t_file_match(got_fname, exp_fname, 'mytest', reps, 1);
+%
+%       t_end;
+%
+%   See also T_OK, T_IS, T_STR_MATCH, T_SKIP, T_BEGIN, T_END, T_RUN_TESTS.
+
+%   MP-Test
+%   Copyright (c) 2004-2022, Power Systems Engineering Research Center (PSERC)
+%   by Ray Zimmerman, PSERC Cornell
+%
+%   This file is part of MP-Test.
+%   Covered by the 3-clause BSD License (see LICENSE file for details).
+%   See https://github.com/MATPOWER/mptest for more info.
+
+%% default arguments
+if nargin < 5
+    del_got_fname = 0;
+    if nargin < 4
+        reps = {};
+    end
+end
+
+%% check existence
+got_exists = exist(got_fname) == 2;
+
+%% compare contents
+if got_exists
+    %% read both files
+    got = fileread(got_fname);
+    expected = fileread(exp_fname);
+
+    %% check if contents match
+    TorF = t_str_match(got, expected, msg, reps);
+    
+    %% delete GOT_FNAME if requested and test passed
+    if TorF && del_got_fname
+        delete(got_fname);
+    end
+else
+    TorF = t_ok(got_exists, [msg ' - missing file']);
+end
+
+if nargout
+    ok = TorF;
+end

--- a/lib/t_str_match.m
+++ b/lib/t_str_match.m
@@ -1,0 +1,73 @@
+function ok = t_str_match(got, expected, msg, reps)
+%T_STR_MATCH  Tests whether two strings/char arrays match.
+%   T_STR_MATCH(GOT, EXPECTED, MSG)
+%   T_STR_MATCH(GOT, EXPECTED, MSG, REPS)
+%   This is equivalent to T_OK(STRCMP(GOT, EXPECTED), MSG), with the
+%   option to apply replacements to GOT, and optionally to EXPECTED,
+%   as specified by REPS before comparing.
+%
+%   The REPS argument is a cell array of replacement specs, applied
+%   sequentially, where each replacement spec is a cell array of the
+%   following form:
+%       {ORIGINAL, REPLACEMENT}
+%       {ORIGINAL, REPLACEMENT, RE}
+%       {ORIGINAL, REPLACEMENT, RE, BOTH}
+%   The ORIGINAL and REPLACEMENT arguments are passed directly as the
+%   2nd and 3rd arguments to REGEXPREP (or to STRREP if RE is present
+%   and false). The replacement applies to GOT only, unless BOTH is
+%   present and true, in which case it also applies to EXPECTED.
+%
+%   Optionally returns a true or false value indicating whether or
+%   not the test succeeded.
+%
+%   Example:
+%       quiet = 0;
+%       t_begin(5, quiet);
+%
+%       % replace Windows EOL chars with Unix EOL chars
+%       reps = {{char([13 10]), char(10), 0, 1}};
+%       got = fileread('test_generated_output.txt');
+%       expected = fileread('expected_output.txt');
+%       t_str_match(got, expected, 'mytest', reps);
+%
+%       t_end;
+%
+%   See also T_OK, T_IS, T_FILE_MATCH, T_SKIP, T_BEGIN, T_END, T_RUN_TESTS.
+
+%   MP-Test
+%   Copyright (c) 2004-2022, Power Systems Engineering Research Center (PSERC)
+%   by Ray Zimmerman, PSERC Cornell
+%
+%   This file is part of MP-Test.
+%   Covered by the 3-clause BSD License (see LICENSE file for details).
+%   See https://github.com/MATPOWER/mptest for more info.
+
+%% default arguments
+if nargin < 4
+    reps = {};
+end
+
+%% do the replacments
+for k = 1:length(reps)
+    rep = reps{k};
+    re = length(rep) < 3 || rep{3};     %% use regexprep()
+    both = length(rep) > 3 && rep{4};   %% repl in expected as well as got
+    if re       %% use regexprep()
+        got = regexprep(got, rep{1}, rep{2});
+        if both
+            expected = regexprep(expected, rep{1}, rep{2});
+        end
+    else        %% use strrep()
+        got = strrep(got, rep{1}, rep{2});
+        if both
+            expected = strrep(expected, rep{1}, rep{2});
+        end
+    end
+end
+
+%% check for match
+TorF = t_ok(strcmp(got, expected), msg);
+
+if nargout
+    ok = TorF;
+end


### PR DESCRIPTION
  - Add `t_str_match()` to test that a string/char array matches an
    expected value. Includes the option to apply a set of regular expression
    or simple string replacements before comparing.
  - Add `t_file_match()` to test that the contents of two text files
    match, with the option to delete one if they do match. Includes
    the option to apply a set of string or regular expresssion replacements
    before comparing.
